### PR TITLE
feat: add render.yaml Infrastructure as Code blueprint

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,15 @@
+services:
+  - type: web
+    name: pontia-modulo4-devops-entregable-grupo2
+    runtime: python
+    region: frankfurt
+    plan: free
+    branch: main
+    rootDir: deployment
+    buildCommand: pip install -r requirements.txt
+    startCommand: uvicorn app.main:app --host 0.0.0.0 --port $PORT
+    envVars:
+      - key: GITHUB_REPO
+        value: SorianoTech/pontia-modulo4-devops-entregable-grupo2
+      - key: PYTHON_VERSION
+        value: "3.10"


### PR DESCRIPTION
## IaC con Render Blueprints (Issue #5)

Se añade el archivo render.yaml en la raíz del repositorio para definir 
la infraestructura como código. Esto permite desplegar el servicio en 
Render sin configuración manual por UI.

Closes #5